### PR TITLE
pnpmのバージョン指定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,8 @@ jobs:
         with:
           node-version: '22.14.0'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
-          version: 10.8.0
           run_install: false
       - name: Get pnpm store directory
         shell: bash

--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
   },
   "engines": {
     "node": ">=22.14.0 <22.15.0"
-  }
+  },
+  "packageManager": "pnpm@10.10.0"
 }


### PR DESCRIPTION
close #48 

## 概要

pnpmのバージョンをpackageManagerに指定するようにしましたのでご確認よろしくお願いいたします。
また、CIの[pnpm/action-setup](https://github.com/pnpm/action-setup)のバージョンが更新されていたので、v4系に更新し、かつバージョンの指定を削除しました。
（デフォルトの挙動がpackageManagerに指定されたバージョンを使用します）

## その他

Corepackを使用するには、以下リンクを参照ください。

https://pnpm.io/ja/installation#corepack-%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%99%E3%82%8B

### Corepackの今後

Node.js v16系で実験的に導入されたが、v25系からNode.jsから分離される。今後はnpmからインストールして使用する形となる。また、Corepack自体が非推奨になったわけではなく、独立したプロジェクトとして開発はされていく。