### PR TITLE
actionlint実行時に警告になったため、環境変数をダブルクォートで囲む

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Get pnpm store directory
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Set pnpm cache
         uses: actions/cache@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get pnpm store directory
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
 
       - name: Set pnpm cache
         uses: actions/cache@v5


### PR DESCRIPTION
## 概要

タイトル通り、actionlint実行時に警告になったため、環境変数をダブルクォートで囲むようにしましたのでご確認よろしくお願いいたします。

## 確認事項

コマンドラインでactionlintを実行し、下記警告が出ないことを確認する

```bash
$ actionlint
.github/workflows/dependabot-auto-merge.yml:24:9: shellcheck reported issue in this script: SC2086:info:1:50: Double quote to prevent globbing and word splitting [shellcheck]
   |
24 |         run: |
   |         ^~~~
.github/workflows/deploy.yml:29:9: shellcheck reported issue in this script: SC2086:info:1:50: Double quote to prevent globbing and word splitting [shellcheck]
   |
29 |         run: |
   |         ^~~~
```