### PR TITLE
Dependabotのdependency-type調整

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 20
     allow:
-      - dependency-type: "all"
+      - dependency-type: "direct"
     versioning-strategy: "increase"
     rebase-strategy: "auto"
 


### PR DESCRIPTION
## 概要

- 関連: https://github.com/uyupun/assets/pull/306
- PNPMの場合、Dependabotは間接依存のアップデートを行えないため、 `dependency-type: "all"` という設定が実際には動作していませんでした
- そのため、設定変更していますが、挙動に変化はなしです