### PR TITLE
Astroを6.3.1から6.3.3へバージョンアップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "0.39.2",
-    "astro": "6.3.1"
+    "astro": "6.3.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: 0.39.2
-        version: 0.39.2(astro@6.3.1(@types/node@25.0.3)(rollup@4.60.3))
+        version: 0.39.2(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.3))
       astro:
-        specifier: 6.3.1
-        version: 6.3.1(@types/node@25.0.3)(rollup@4.60.3)
+        specifier: 6.3.3
+        version: 6.3.3(@types/node@25.0.3)(rollup@4.60.3)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.15
@@ -36,8 +36,14 @@ packages:
   '@astrojs/internal-helpers@0.9.0':
     resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
 
+  '@astrojs/internal-helpers@0.9.1':
+    resolution: {integrity: sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==}
+
   '@astrojs/markdown-remark@7.1.1':
     resolution: {integrity: sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==}
+
+  '@astrojs/markdown-remark@7.1.2':
+    resolution: {integrity: sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==}
 
   '@astrojs/mdx@5.0.4':
     resolution: {integrity: sha512-tSbuuYueNODiFAFaME7pjHY5lOLoxBYJi1cKd6scw9+a4ZO7C7UGdafEoVAQvOV2eO8a6RaHSAJYGVPL1w8BPA==}
@@ -47,6 +53,10 @@ packages:
 
   '@astrojs/prism@4.0.1':
     resolution: {integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==}
+    engines: {node: '>=22.12.0'}
+
+  '@astrojs/prism@4.0.2':
+    resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
     engines: {node: '>=22.12.0'}
 
   '@astrojs/sitemap@3.7.2':
@@ -754,8 +764,8 @@ packages:
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
-  astro@6.3.1:
-    resolution: {integrity: sha512-atz6dmkE3Gu24bDgb7g2RE/BYnKqPYIHd6hTUM1UXvu/i7qNZOKLAqEHvgYpv9PQVcgWsXpk4/OOXZ0E/FzvSQ==}
+  astro@6.3.3:
+    resolution: {integrity: sha512-wvLIZQYbBZt6U8gyflBW4SLBypaqdwLZUH93rT3oT53cmQ0bTGubvMAGjqBRoheOYzYcTJZtW6czztzbu4kQ5g==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -1914,6 +1924,10 @@ snapshots:
     dependencies:
       picomatch: 4.0.4
 
+  '@astrojs/internal-helpers@0.9.1':
+    dependencies:
+      picomatch: 4.0.4
+
   '@astrojs/markdown-remark@7.1.1':
     dependencies:
       '@astrojs/internal-helpers': 0.9.0
@@ -1940,12 +1954,38 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.4(astro@6.3.1(@types/node@25.0.3)(rollup@4.60.3))':
+  '@astrojs/markdown-remark@7.1.2':
+    dependencies:
+      '@astrojs/internal-helpers': 0.9.1
+      '@astrojs/prism': 4.0.2
+      github-slugger: 2.0.0
+      hast-util-from-html: 2.0.3
+      hast-util-to-text: 4.0.2
+      js-yaml: 4.1.1
+      mdast-util-definitions: 6.0.0
+      rehype-raw: 7.0.0
+      rehype-stringify: 10.0.1
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      remark-smartypants: 3.0.2
+      retext-smartypants: 6.2.0
+      shiki: 4.0.2
+      smol-toml: 1.6.1
+      unified: 11.0.5
+      unist-util-remove-position: 5.0.0
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@astrojs/mdx@5.0.4(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.1
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.3.1(@types/node@25.0.3)(rollup@4.60.3)
+      astro: 6.3.3(@types/node@25.0.3)(rollup@4.60.3)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -1963,23 +2003,27 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
+  '@astrojs/prism@4.0.2':
+    dependencies:
+      prismjs: 1.30.0
+
   '@astrojs/sitemap@3.7.2':
     dependencies:
       sitemap: 9.0.1
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.39.2(astro@6.3.1(@types/node@25.0.3)(rollup@4.60.3))':
+  '@astrojs/starlight@0.39.2(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.1
-      '@astrojs/mdx': 5.0.4(astro@6.3.1(@types/node@25.0.3)(rollup@4.60.3))
+      '@astrojs/mdx': 5.0.4(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.3))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.3.1(@types/node@25.0.3)(rollup@4.60.3)
-      astro-expressive-code: 0.42.0(astro@6.3.1(@types/node@25.0.3)(rollup@4.60.3))
+      astro: 6.3.3(@types/node@25.0.3)(rollup@4.60.3)
+      astro-expressive-code: 0.42.0(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -2536,16 +2580,16 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.42.0(astro@6.3.1(@types/node@25.0.3)(rollup@4.60.3)):
+  astro-expressive-code@0.42.0(astro@6.3.3(@types/node@25.0.3)(rollup@4.60.3)):
     dependencies:
-      astro: 6.3.1(@types/node@25.0.3)(rollup@4.60.3)
+      astro: 6.3.3(@types/node@25.0.3)(rollup@4.60.3)
       rehype-expressive-code: 0.42.0
 
-  astro@6.3.1(@types/node@25.0.3)(rollup@4.60.3):
+  astro@6.3.3(@types/node@25.0.3)(rollup@4.60.3):
     dependencies:
       '@astrojs/compiler': 4.0.0
-      '@astrojs/internal-helpers': 0.9.0
-      '@astrojs/markdown-remark': 7.1.1
+      '@astrojs/internal-helpers': 0.9.1
+      '@astrojs/markdown-remark': 7.1.2
       '@astrojs/telemetry': 3.3.2
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.3.0


### PR DESCRIPTION
# 概要

- Astro を 6.3.1 -> 6.3.3 へ更新
- 元々はdependabotによるPR: https://github.com/uyupun/takada-semi/pull/290
- こちらのPRにおいて、astroの更新と、間接依存しているjs-yamlの更新も行われていた
- js-yamlが更新されていたのは、プロトタイプ汚染の脆弱性が含まれるバージョンだったから
- js-yamlの更新は、 `overrides` を使用し、半ば無理やりバージョンが上げられていた
- lockファイルのみにoverridesを記載していたため、 `--frozen-lockfile` でCIが落ちていた模様
- 悪意のあるYAMLが埋め込まれない限り、この脆弱性を発現できないため、本リポジトリでリスクは低いと判断
- むしろ、今後 `overrides` が増えてしまうとメンテコストが上がる可能性がある
- そのため、Astroのアップデートのみに留める