### PR TITLE
Increase Dependabot auto-merge retry limit and delay

### DIFF
--- a/.github/workflows/retry-dependabot-auto-merge.yml
+++ b/.github/workflows/retry-dependabot-auto-merge.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.run_attempt < 2
+      github.event.workflow_run.run_attempt < 4
     steps:
       - name: Random delay before retry
         run: |
-          delay=$((RANDOM % 121 + 60))
+          delay=$((RANDOM % 181 + 120))
           echo "Waiting ${delay} seconds before retry..."
           sleep $delay
 


### PR DESCRIPTION
## Summary
- Dependabot auto-mergeの自動リトライ回数を最大1回→最大3回に増やす (`run_attempt < 2` → `run_attempt < 4`)
- リトライ前の待機時間を60〜180秒→120〜300秒に延長

複数のDependabot PRがほぼ同時に作成されると、GitHub側のPR状態(mergeable state)計算が間に合わず `Auto merge is not allowed for this repository` が一時的に返ることがある。リトライ回数・待機時間を増やすことで、この一時的な失敗を吸収しやすくする。

## Test plan
- [ ] 次回Dependabotのバッチ実行時にワークフローが正常に動作することを確認